### PR TITLE
fix: add lib target for package

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,3 +11,6 @@ starknet = "=2.1.1"
 [[target.starknet-contract]]
 allowed-libfuncs-list.name = "audited"
 casm = true
+
+[lib]
+allowed-libfuncs-list.name = "audited"


### PR DESCRIPTION
without this lib target it cannot be used as dependency for another scarb project

see: https://docs.swmansion.com/scarb/docs/reference/targets.html#library